### PR TITLE
ちょっと柔軟にコンパイルできるようにする

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,7 @@
-rm dist/domain.png &&\
-cat src/domain.pu | docker run --rm -i curelemonade/plantuml -tpng > dist/domain.png &&\
-git add dist/domain.png
+rm -f dist/*.png
+for filepath in `ls src/*.pu`
+do
+    base=`basename $filepath .pu`
+    cat $filepath | docker run --rm -i curelemonade/plantuml -tpng > dist/${base}.png
+    git add dist/*.png
+done


### PR DESCRIPTION
dist以下を全部消してコンパイルし直す

# 問題点
- src以下にディレクトリが増えることに対応できていない
- 差分コンパイルはできていない

差分コンパイルを目指すときに`削除されたumlファイルに応じてpngを消す`というところが課題になる気がする。   
makeでうまく書ける気もする。